### PR TITLE
Extensionの設定を厳しめにしました

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,8 +3,10 @@
   "name": "Copy URL",
   "version": "1.0.0",
   "description": "いい感じでURLをコピーする",
-  "permissions": ["contextMenus", "tabs", "http://*/*", "https://*/*"],
+  "permissions": ["contextMenus"],
   "background": {
-    "scripts": ["js/background.js"]
+    "matches": ["https://www.youtube.com/*", "https://www.amazon.co.jp/*"],
+    "scripts": ["js/background.js"],
+    "persistent": false
   }
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -101,6 +101,7 @@ chrome.runtime.onInstalled.addListener((): void => {
   chrome.contextMenus.create({
     id: "copyurl",
     title: "いい感じでURLをコピー",
+    documentUrlPatterns: ["https://www.youtube.com/*", "https://www.amazon.co.jp/*"]
   });
 });
 


### PR DESCRIPTION
YoutubeとAmazon以外のページではこのGoogle拡張は必要ないので、以下にマッチするURL以外のページではContextMenuに表示しないようにしました。
- "https://www.youtube.com/*"
- "https://www.amazon.co.jp/*

また、不要なpermissionを削除しました。